### PR TITLE
Adding info to import vagrant-box for aws provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Vagrant.configure('2') do |config|
 
     aws.region = 'eu-west-1'
     aws.instance_type = 'm3.large'
-    aws.ami = 'ami-827f00ea'
+    aws.ami = '' # due to a bug, see https://github.com/mitchellh/vagrant-aws/issues/330
     aws.access_key_id = '<aws-access-key>'
     aws.secret_access_key = '<aws-secret-key>'
     aws.keypair_name = '<keypair-name>'

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Based on [official Debian AMIs](https://wiki.debian.org/Cloud/AmazonEC2Image/Whe
 Using the *HVM EBS* flavor as [recommended](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html) by Amazon.
 Available regions: `eu-west-1`, `us-east-1`.
 
+##### Install the box for provider aws if not already done so
+```shell
+vagrant box add cargomedia/debian-7-amd64-default --provider aws
+```
+
 Example `Vagrantfile` (using the [vagrant AWS provider plugin](https://github.com/mitchellh/vagrant-aws)):
 ```ruby
 Vagrant.configure('2') do |config|

--- a/README.md
+++ b/README.md
@@ -25,11 +25,6 @@ Based on [official Debian AMIs](https://wiki.debian.org/Cloud/AmazonEC2Image/Whe
 Using the *HVM EBS* flavor as [recommended](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html) by Amazon.
 Available regions: `eu-west-1`, `us-east-1`.
 
-##### Install the box for provider aws if not already done so
-```shell
-vagrant box add cargomedia/debian-7-amd64-default --provider aws
-```
-
 Example `Vagrantfile` (using the [vagrant AWS provider plugin](https://github.com/mitchellh/vagrant-aws)):
 ```ruby
 Vagrant.configure('2') do |config|
@@ -41,6 +36,7 @@ Vagrant.configure('2') do |config|
 
     aws.region = 'eu-west-1'
     aws.instance_type = 'm3.large'
+    aws.ami = 'ami-827f00ea'
     aws.access_key_id = '<aws-access-key>'
     aws.secret_access_key = '<aws-secret-key>'
     aws.keypair_name = '<keypair-name>'


### PR DESCRIPTION
To properly start vagrant instances on AWS, the box needs to be imported first - this does not happen automatically as in a virtualbox `vagrant up`

@njam please review