### PR TITLE
Prevent puppet agent from starting at boot

### DIFF
--- a/spec/puppet.rb
+++ b/spec/puppet.rb
@@ -16,3 +16,7 @@ end
 describe command('puppet config print') do
   its(:stdout) { should match 'ssldir = /etc/puppet/ssl' }
 end
+
+describe service('puppet') do
+  it { should_not be_running }
+end

--- a/ubuntu-1504/scripts/puppet.sh
+++ b/ubuntu-1504/scripts/puppet.sh
@@ -4,6 +4,13 @@ dpkg -i puppetlabs-release-pc1-vivid.deb
 rm puppetlabs-release-pc1-vivid.deb
 apt-get update
 
+# Prevent puppet agent from auto-starting
+mkdir -p /etc/systemd/system/puppet.service.d
+cat > /etc/systemd/system/puppet.service.d/disable.conf << EOF
+[Service]
+EnvironmentFile=/not/there
+EOF
+
 # Install puppet/facter
 apt-get install -y puppet facter
 

--- a/ubuntu-1504/scripts/puppet.sh
+++ b/ubuntu-1504/scripts/puppet.sh
@@ -4,13 +4,6 @@ dpkg -i puppetlabs-release-pc1-vivid.deb
 rm puppetlabs-release-pc1-vivid.deb
 apt-get update
 
-# Prevent puppet agent from auto-starting
-mkdir -p /etc/systemd/system/puppet.service.d
-cat > /etc/systemd/system/puppet.service.d/disable.conf << EOF
-[Service]
-EnvironmentFile=/not/there
-EOF
-
 # Install puppet/facter
 apt-get install -y puppet facter
 
@@ -22,3 +15,8 @@ ssldir = /etc/puppet/ssl
 logdir = /var/log/puppet
 rundir = /var/run/puppet
 EOF
+
+# Reinstall puppet.service when needed (no autostart)
+systemctl stop puppet
+rm -f /lib/systemd/system/puppet.service /var/lib/puppet/state/agent_disabled.lock /etc/init.d/puppet
+systemctl daemon-reload


### PR DESCRIPTION
This is an annoying thing. Before we had a file `etc/default/puppet` with a default `START=NO` meant to block puppet agent before configuration was not done

There are claims about this to be fixed, but I haven't been able to reproduce - ie puppet was always found starting even though that lock file is present in two places: `/run/puppet/state/agent_disabled.lock` and `/var/lib/puppet/state/agent_disabled.lock`

So I came up with this somehow ugly hack