### PR TITLE
Date-based versioning template for vagrant boxes

### DIFF
--- a/lib/vagrant_boxes/template.rb
+++ b/lib/vagrant_boxes/template.rb
@@ -90,12 +90,9 @@ module VagrantBoxes
 
     def next_version
       box = environment.vagrant_cloud.ensure_box(name)
-      versions = box.versions
-      if versions.empty?
-        version_name = '0.1.0'
-      else
-        version_name = Gem::Version.new(versions.last.version).bump.to_s + '.0'
-      end
+      version_name = 'v' + Time.now.strftime("%Y%m%d")
+      todays_versions = box.versions.select {|v| v =~ /^#{version_name}/}.size
+      version_name += "-rev#{todays_versions}" if todays_versions > 0
       box.create_version(version_name)
     end
 


### PR DESCRIPTION
Due to this bug https://github.com/mitchellh/vagrant/issues/7582 and complaints from devs

>[2:16 PM] Philipp Pfaff: new vagrant box is released (https://atlas.hashicorp.com/cargomedia/boxes/debian-8-amd64-cm)
[2:17 PM] Philipp Pfaff:
    vagrant box update
[2:19 PM] Vladimir Finko: btw I met a weird thing. after upgrade was run,  the box isn't updated until you delete old versions of it.
not sure if it's only my local "bug"
[2:20 PM] Reto Kaiser: it's expected behaviour, "update" will just download the new image, but not wipe your local box
[2:20 PM] Reto Kaiser: you'll need to "destroy" and "up" again
[2:23 PM] Vladimir Finko: hmm it does nothing to it.. starting from 0.10.0 it tried to load older version.. ie 0.9.0 after deleting 0.9.0 it loaded 0.7.0 etc, but not existing 0.10.0 or 0.11.0
[2:25 PM] Philipp Pfaff: what is the output of
[2:25 PM] Philipp Pfaff:
    vagrant box list
[2:26 PM] Philipp Pfaff:
    # You can also try
    vagrant box add cargomedia/debian-8-amd64-cm
    # or even
    vagrant box add cargomedia/debian-8-amd64-cm --force
[2:26 PM] Vladimir Finko: @ppp0 it's not a case since i manually removed outdated boxes.
[2:26 PM] Philipp Pfaff: you mean you have no output when you list boxes?
[2:27 PM] Vladimir Finko: i had, it was okay, just all boxes and several versions for some of them like for 'cargomedia/debian-8-amd64-cm'
[2:28 PM] Philipp Pfaff: and your current version is? sorry I don't get fully what happens
[2:28 PM] Philipp Pfaff:
    |  hmm it does nothing to it.. starting from 0.10.0 it tried to load older version.. ie 0.9.0 after deleting 0.9.0 it loaded 0.7.0 etc, but not existing 0.10.0 or 0.11.0
[2:29 PM] Philipp Pfaff: sounds like some counter being mistaken?.. or worse
[2:29 PM] Philipp Pfaff:
    irb(main):002:0> "0.11.0" < "0.7.0"
    => true
[2:30 PM] Vladimir Finko: let's say i have 0.9.0 
after vagrant destroy; vagrant box update; vagrant up 
it's still 0.9.0
but 0.11.0 presents in `vagrant box list` output.
after deleting 0.9.0 it became okay and loaded 0.11.0
[2:31 PM] Philipp Pfaff: may be we should open a ticket...