### PR TITLE
Revert "Date-based versioning template for vagrant boxes"

### DIFF
--- a/lib/vagrant_boxes/template.rb
+++ b/lib/vagrant_boxes/template.rb
@@ -90,9 +90,12 @@ module VagrantBoxes
 
     def next_version
       box = environment.vagrant_cloud.ensure_box(name)
-      version_name = 'v' + Time.now.strftime("%Y%m%d")
-      todays_versions = box.versions.select {|v| v =~ /^#{version_name}/}.size
-      version_name += "-rev#{todays_versions}" if todays_versions > 0
+      versions = box.versions
+      if versions.empty?
+        version_name = '0.1.0'
+      else
+        version_name = Gem::Version.new(versions.last.version).bump.to_s + '.0'
+      end
       box.create_version(version_name)
     end
 


### PR DESCRIPTION
Reverts cargomedia/vagrant-boxes#90

Unfortunately, uploading a box errors with 422
`RestClient::UnprocessableEntity: 422 Unprocessable Entity``

If I try to version manually, I get an error. Apparently the [RubyGems Versioning Schema](http://guides.rubygems.org/patterns/#semantic-versioning) is required.

<img width="506" alt="screen shot 2017-01-25 at 14 12 58" src="https://cloud.githubusercontent.com/assets/1888714/22291883/e03b2c5c-e308-11e6-815b-35e7f70d02a2.png">

I thought we do it analogous to https://atlas.hashicorp.com/puphpet/boxes/ubuntu1404-x64 but it seems not to be allowed

<img width="1107" alt="screen shot 2017-01-25 at 14 17 53" src="https://cloud.githubusercontent.com/assets/1888714/22291918/1b31e47c-e309-11e6-9ba6-c0007cabfcc2.png">
